### PR TITLE
Initial Commit

### DIFF
--- a/PKGBUILD
+++ b/PKGBUILD
@@ -1,0 +1,12 @@
+# Maintainer:  echo -n 'bWljaGFsQGdldGNyeXN0LmFs'     | base64 -d
+# Contributor: echo -n 'bWF0dEBnZXRjcnlzdC5hbA=='     | base64 -d
+# Contributor: echo -n 'cmNhbmRhdUBnZXRjcnlzdC5hbA==' | base64 -d
+
+pkgname=crystal-core
+pkgver=1
+pkgrel=1
+pkgdesc='Minimal package set to define a basic Crystal Linux installation'
+url='https://getcryst.al'
+arch=('any')
+license=('GPL3')
+depends=('ame' 'crystal-keyring' 'crystal-mirrorlist')


### PR DESCRIPTION
Hi team,

I suggested dropping the [crystal's base package](https://github.com/crystal-linux-packages/base) in favor of a package dedicated to install specific crystal stuff.
Indeed, IMO we should let Arch handle the `base` stuffs and just add what we need to add on top of it in a separate package; instead of handling the whole `base` package ourself, dealing with updates, remember to set a higher `pkgver` than Arch, etc...
It feels much more "elegant" and easier to maintain for the future.

@not-my-segfault suggested the name `crystal-core` which I like! :)

So there it is, this package basically just pulls `ame`, `crystal-keyring` and `crystal-mirrorlist` as dependencies and... that's about it :)

That implies removing the [crystal's base package](https://github.com/crystal-linux-packages/base) from both GitHub and Crystal's repos in order to install the regular Arch's `base` package instead.

What do you think?